### PR TITLE
Fix Crash In Lottie Android export caused by images

### DIFF
--- a/Packages/Lottie/lib/assets.flp
+++ b/Packages/Lottie/lib/assets.flp
@@ -152,8 +152,8 @@ func imageDictionary(from image, imageFolderName)
     return [
         "id":"\(image.name)", 
         "p": "data:image/png;base64,\(image.base64Encoded())", 
-        "w": image.size.width,
-        "h": image.size.height,
+        "w": image.size.width.rounded(),
+        "h": image.size.height.rounded(),
         "e": 1,
         "u": "\(imageFolderName)/"
     ]

--- a/Packages/Lottie/signatures.json
+++ b/Packages/Lottie/signatures.json
@@ -1,6 +1,6 @@
 {
   "lib\/animation.flp" : "MEYCIQC5QzkgS4lNIQjPJ3fuhZr7XTjVxU\/BLUxoEl+b6nJNOgIhAOSbEPZd3ncp70qtX8arS22\/RfOLyBgwLNTYzdVMxznP",
-  "lib\/assets.flp" : "MEQCIA3EQSuOyLCdp1uj\/UrO3MBCijyNN\/1XC3vb8UMWnfpdAiBzAZti8kerYat3K07Ybym1pPAKV6NSSUcQAvPWkdcXYw==",
+  "lib\/assets.flp" : "MEQCIETEWCRB7HQyuf4iwkVDguRCycdoOC07Bwh2jBpVSqhBAiA\/G4F8+oNl6RrDqkrwg6os2hJ9ykxPqK202fSIY6pqQQ==",
   "lib\/characters.flp" : "MEQCICgaQ9pGNgowr8qblG6G7LPyju\/ZvaDXk\/irGfCVXbOVAiAITAe\/CCGJhSQCkb6r+0pFIVPd9aecarK0qe85UBU5RA==",
   "lib\/composition.flp" : "MEUCIHZynJXweeMb\/\/\/R0e7fPLu8My4ddN1DbH\/yJIeELCvYAiEA7xnq\/cJ60wkVwUmMt0zTGs1NhHam31SMbKtg53TcLyQ=",
   "lib\/contentMode.flp" : "MEQCIEKZJ3W3eUhM\/xighGFSE8lGWkNfnQOnmY6BpSc2n\/QZAiBvOR3ovAie6IWSzPw6Do93vt2fwFeCBUmBL3EERFF46g==",


### PR DESCRIPTION
round width and height of image assets, because Androind Lottie parsers expects them to be ints other wise it crashes.