### PR TITLE
Fix fill issue for web animations

### DIFF
--- a/Packages/Web/templates/js/trackConstructor.js.flt
+++ b/Packages/Web/templates/js/trackConstructor.js.flt
@@ -12,7 +12,7 @@ trackNames = trackNames.appending(trackName)
       {
         duration: this.duration,
         composite: <%= timelineName %>Timeline.composite.REPLACE,
-        fill: <%= timelineName %>Timeline.composite.FORWARDS
+        fill: <%= timelineName %>Timeline.fill.FORWARDS
       }
     )
 }


### PR DESCRIPTION
Fill animations weren't being set properly, all web exports are currently "broken" because of this. 

Can someone please handle this pr, and do the proper signatures / etc. 