### PR TITLE
Fixes background color scaling bug

### DIFF
--- a/iOS-CustomUIButton.flood/Project/Sources/Button.swift.flt
+++ b/iOS-CustomUIButton.flood/Project/Sources/Button.swift.flt
@@ -15,6 +15,10 @@ class <%= buttonClassName %>: ToggleButton {
         startView.clipsToBounds = false
         //Let the button do the clipping
         clipsToBounds = <%= initialRootSnapshot.masksToBounds %>
+        //Since we are scaling, set the background color of the button, and clear the backgroundColor of the startview
+        backgroundColor = startView.backgroundColor
+        startView.backgroundColor = .clear
+
         return startView
     }()
 

--- a/iOS-CustomUIButton.flood/Project/Sources/ToggleButton.swift
+++ b/iOS-CustomUIButton.flood/Project/Sources/ToggleButton.swift
@@ -40,6 +40,7 @@ class ToggleButton: UIButton {
 
     private func setupView() {
         view = createView()
+        view.isUserInteractionEnabled = false
         addSubview(view)
     }
 

--- a/iOS-CustomUIButton.flood/signatures.json
+++ b/iOS-CustomUIButton.flood/signatures.json
@@ -6,7 +6,7 @@
   "Project\/Resources\/Info.plist.flt" : "MEUCIQDlWu+rJnDpMAdtvY9zUMUBY7lO2HBPY+2gEP1mZoOZKgIgeQANYVwszdk82tQXLdbnO+s612rd4jNVNR6Qy6JGBf4=",
   "Project\/Sources\/AnimationInitialization.swift.flt" : "MEUCIEqKN7RVH4WSz4H1iD6Ui7M4nmtsnPoAHSoexBJnFk5jAiEAjzs8sd+Gh8ZIuEfJOWkGNrbG0U0d4UqT28FEwWCzfRM=",
   "Project\/Sources\/Animations.swift.flt" : "MEUCICuvXwiXnogQe9\/yk4E3\/FQ+B1ugUowKfem8QGewH2xWAiEAzxF76cEcO8OwY+hknLyN+UchzFrA3ZkHeIskMIU+M2U=",
-  "Project\/Sources\/Button.swift.flt" : "MEUCIQDzUMINMWlTbHB6vhyGwOQiI3DgqaY08nhTZ4YO4m3jYwIgFNTCKmA41P2GuxIl+gTUZSuMflhOE1uwtgL3UcDz+PM=",
+  "Project\/Sources\/Button.swift.flt" : "MEYCIQCrq07465znPJhaOnukF03rHM+pvRhXmns0s1HoTFZZkAIhAOGWDHwJKnG3smFbnULtxcEYJICh00SnhH5Ja2slsniW",
   "Project\/Sources\/CreateSounds.flt" : "MEUCIDD0fajsqcbQWTrOgpThSt4NzcXOsxtW7KsBTpsasME6AiEA0TMDMjPNVZxc9atwUuDOj99hcDlYBz47kZgGoytw3jw=",
   "README.html.flt" : "MEUCIQD3HqNu2dLQh7M3w86TTtQpMUIgRatbZ9JXC88qyT2I4wIgaZMy1Xsy\/pcz4+UrztAH2v+8q2FvuMwVDxYc0OD3NFg=",
   "READMEBody.html.flt" : "MEYCIQD4dZK2RIZC8IHkWG6MAvQslQ9DCSukBBdTNdOStT7KXQIhAMFJMe14zc\/rIcWBZDOjlIorn9HpZ+wKmR9FAuUVmLTf"


### PR DESCRIPTION
Our default behvaiour when exporting is to set the background color of the button in Interface Builder. This is fine when only considering a single file. However, when reusing an instance of a button in IB with various ToggleButton subclasses, the background color cannot abide solely by the IB variable.

This fix changes the behaviour so that it makes the background dynamically sync with the defaults of the current custom view.

It also disables interaction on the custom view itself.